### PR TITLE
CSS animations for sections and hero section shapes

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -210,6 +210,7 @@ a.button {
     background-color: lighten($btn-bg-color, 15%);
     color: lighten($btn-color, 15%);
     border-color: lighten($btn-border-color, 15%);
+    box-shadow: $btn-box-shadow;
   }
 
   &.secondary {

--- a/_sass/_keyframes.scss
+++ b/_sass/_keyframes.scss
@@ -1,0 +1,47 @@
+// CSS animation keyframes for various elements
+
+// Sections and footer keyframes
+@keyframes section-fade-in {
+  0% {
+    opacity: 0;
+    transform: translateY(-2rem);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+// Hero section elements keyframes
+@keyframes hero-fade-in-bg {
+  from {
+    opacity: 0;
+    transform: var(--hero-bg-transform-from, translate(150%,7%));
+  }
+  to {
+    opacity: 0.2;
+    transform: var(--hero-bg-transform-to, translate(160%,-7%));
+  }
+}
+
+@keyframes hero-fade-in-fg {
+  from {
+    opacity: 0;
+    transform: var(--hero-fg-transform-from, translate(150%,7%));
+  }
+  to {
+    opacity: 1;
+    transform: var(--hero-fg-transform-to, translate(140%,17%));
+  }
+}
+
+@keyframes hero-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-10%);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -70,6 +70,16 @@ section {
   }
 }
 
+section:not(.hero),
+.wrapper > footer {
+  opacity: 0;
+  animation: section-fade-in 1.8s ease forwards;
+
+  @supports not (animation: name) {
+    opacity: 1;
+  }
+}
+
 @import 'sections/hero';
 @import 'sections/slider';
 @import 'sections/accordion';

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -154,7 +154,7 @@ $btn-border-width:            $input-btn-border-width !default;
 $btn-border-color:            $blue-dark-color !default;
 
 $btn-font-weight:             $font-weight-medium !default;
-$btn-box-shadow:              inset 0 1px 0 rgba($white, .15), 0 1px 1px rgba($black, .075) !default;
+$btn-box-shadow:              rgba(50, 50, 93, 0.25) 0px 13px 27px -5px, rgba(0, 0, 0, 0.3) 0px 8px 16px -8px;
 $btn-disabled-opacity:        .65 !default;
 $btn-active-box-shadow:       inset 0 3px 5px rgba($black, .125) !default;
 
@@ -162,4 +162,4 @@ $btn-border-radius:           $border-radius !default;
 $btn-border-radius-sm:        $border-radius-sm !default;
 $btn-border-radius-lg:        $border-radius-lg !default;
 
-$btn-transition:              color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
+$btn-transition:              color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .3s ease-in-out !default;

--- a/_sass/jekyll-theme-ss-nes.scss
+++ b/_sass/jekyll-theme-ss-nes.scss
@@ -5,6 +5,7 @@
   "mixins",
   "fonts/open-sans-latin",
   "fonts/dm-sans-latin",
+  "keyframes",
   "base",
   "layout"
 ;

--- a/_sass/sections/_hero.scss
+++ b/_sass/sections/_hero.scss
@@ -65,6 +65,12 @@ section.hero {
   .container {
     position: relative;
     z-index: 3; // Ensure container is above background images
+    opacity: 0;
+    animation: hero-fade-in 1.5s ease forwards;
+
+    @supports not (animation: name) {
+      opacity: 1;
+    }
   }
 
   header,

--- a/_sass/sections/_hero.scss
+++ b/_sass/sections/_hero.scss
@@ -14,51 +14,74 @@ section.hero {
   // Hero decoration image (background)
   &:before {
     @include media-breakpoint-up(md) {
+      --hero-bg-transform-from: translate(150%,-10%);
+      --hero-bg-transform-to: translate(160%,-20%);
       content: '';
       position: absolute;
       top: 0;
       left: 0;
-      transform: translate(160%,-20%);
+      transform: var(--hero-bg-transform-to, translate(160%,-20%));
       z-index: 1;
       width: 40%;
       height: 80%;
       background: transparent url('/assets/img/header-bg/hero-shape-bg.svg') no-repeat center center;
       background-size: 100% 100%;
       max-height: 80vh;
-      opacity: 0.2;
+      opacity: 0;
+      animation: hero-fade-in-bg 0.8s ease 0.4s forwards;
+    }
+
+    @supports not (animation: name) {
+      @include media-breakpoint-up(md) {
+        opacity: 0.2;
+      }
     }
 
     @include media-breakpoint-up(lg) {
-      transform: translate(160%,-7%);
+      --hero-bg-transform-from: translate(150%,7%);
+      --hero-bg-transform-to: translate(160%,-7%);
     }
 
     @media (max-height: #{map-get($grid-breakpoints, md) - 0.02}) and (orientation: landscape) {
-      transform: translate(160%,-7%);
+      --hero-bg-transform-from: translate(150%,7%);
+      --hero-bg-transform-to: translate(160%,-7%);
     }
   }
 
   // Hero decoration image (foreground)
   &:after {
     @include media-breakpoint-up(md) {
+      --hero-fg-transform-from: translate(150%,7%);
+      --hero-fg-transform-to: translate(140%,0%);
       content: '';
       position: absolute;
       top: 0;
       left: 0;
-      transform: translate(140%,0%);
+      transform: var(--hero-fg-transform-to, translate(140%,0%));
       z-index: 2;
       width: 40%;
       height: 80%;
       background: transparent url('/assets/img/header-bg/hero-shape-fg.svg') no-repeat center center;
       background-size: 100% 100%;
       max-height: 80vh;
+      opacity: 0;
+      animation: hero-fade-in-fg 0.8s ease 0.2s forwards;
+    }
+
+    @supports not (animation: name) {
+      @include media-breakpoint-up(md) {
+        opacity: 1;
+      }
     }
 
     @include media-breakpoint-up(lg) {
-      transform: translate(140%,17%);
+      --hero-fg-transform-from: translate(150%,7%);
+      --hero-fg-transform-to: translate(140%,17%);
     }
 
     @media (max-height: #{map-get($grid-breakpoints, md) - 0.02}) and (orientation: landscape) {
-      transform: translate(140%,17%);
+      --hero-fg-transform-from: translate(150%,7%);
+      --hero-fg-transform-to: translate(140%,17%);
     }
   }
 


### PR DESCRIPTION
This pull request adds CSS animations to fade in the Hero section shapes and other section containers at page load, in order to give the website a more lively feel to it (less static).

It also adds a box shadow effect on hover for all buttons.

Note: when the CSS `animation` property is not supported, CSS' `@supports not` is used to properly show elements that had opacity set to `0` for animation purposes.